### PR TITLE
Update release notes for v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 0.1.1 (02/14/2020)
+
+* Handle getLinkingMetadata not returning an object.
+
 ## 0.1.0 (11/26/2019)
 
 * Initial release of log formatter.


### PR DESCRIPTION
 * Handle `getLinkingMetadata` not returning an object.