### PR TITLE
Still log when disabled

### DIFF
--- a/lib/createFormatter.js
+++ b/lib/createFormatter.js
@@ -5,11 +5,10 @@ const truncate = require('./truncate')
 module.exports = function createFormatter(newrelic) {
   const jsonFormatter = winston.format.json()
   return winston.format((info, opts) => {
-    const metadata = newrelic.getLinkingMetadata(true)
-
-    // Handle agents without the appropriate getLinkingMetadata stub
-    if (metadata === undefined) {
-      return
+    // Using Stub API, agent is not enabled.
+    if (!newrelic.shim) {
+      // Still log user's original details
+      return jsonFormatter.transform(info, opts)
     }
 
     if (info.exception === true) {
@@ -36,6 +35,8 @@ module.exports = function createFormatter(newrelic) {
       info.original_timestamp = info.timestamp
     }
     info.timestamp = Date.now()
+
+    const metadata = newrelic.getLinkingMetadata(true)
 
     // Add the metadata to the info object being logged
     Object.keys(metadata).forEach(m => {

--- a/lib/createFormatter.js
+++ b/lib/createFormatter.js
@@ -3,14 +3,15 @@ const winston = require('winston')
 const truncate = require('./truncate')
 
 module.exports = function createFormatter(newrelic) {
-  const jsonFormatter = winston.format.json()
-  return winston.format((info, opts) => {
-    // Using Stub API, agent is not enabled.
-    if (!newrelic.shim) {
-      // Still log user's original details
-      return jsonFormatter.transform(info, opts)
-    }
+  // Stub API means agent is not enabled.
+  if (!newrelic.shim) {
+    // Continue to log original message with JSON formatter
+    return winston.format.json
+  }
 
+  const jsonFormatter = winston.format.json()
+
+  return winston.format((info, opts) => {
     if (info.exception === true) {
       // Due to Winston internals sometimes the error on the info object is a string or an
       // empty object, and so the message property is all we have

--- a/lib/createFormatter.js
+++ b/lib/createFormatter.js
@@ -9,6 +9,8 @@ module.exports = function createFormatter(newrelic) {
     return winston.format.json
   }
 
+  createModuleUsageMetric(newrelic.shim.agent)
+
   const jsonFormatter = winston.format.json()
 
   return winston.format((info, opts) => {
@@ -46,4 +48,10 @@ module.exports = function createFormatter(newrelic) {
 
     return jsonFormatter.transform(info, opts)
   })
+}
+
+function createModuleUsageMetric(agent) {
+  agent.metrics.getOrCreateMetric(
+    'Supportability/ExternalModules/WinstonLogEnricher'
+  ).incrementCallCount()
 }


### PR DESCRIPTION
<!--
Thank you for submitting a Pull Request.

This code is leveraged to monitor critical services. Please consider the following:
* Tests are required.
* Performance matters.
* Features that are specific to just your app are unlikely to make it in.

Please fill out the relevant sections as follows:
* Proposed Release Notes: Bulleted list of recommended release notes for the change(s).
* Links: Any relevant links for the change.
* Details: In-depth description of changes, other technical notes, etc.
-->

## Proposed Release Notes

* Fixed several bugs where the formatter would have unexpected results when the agent is disabled. Fixes include:
  * Now always logs via JSON format.
  * Does not modify original content when the agent is disabled.
  * Does not crash with the existence of a timestamp field when the agent is disabled.

* Added module load support metric.

## Links

* Fixes: https://github.com/newrelic/newrelic-winston-logenricher-node/issues/29
* Fixes: https://github.com/newrelic/newrelic-winston-logenricher-node/issues/38

## Details
